### PR TITLE
upgrade: Update gulp-s3-upload dep to remove its flatmap-stream dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "gulp-postcss": "8.0.0",
     "gulp-rename": "1.4.0",
     "gulp-rev": "9.0.0",
-    "gulp-s3-upload": "1.7.0",
+    "gulp-s3-upload": "1.7.1",
     "gulp-sass": "4.0.2",
     "gulp-sentry-release": "1.0.4",
     "gulp-shell": "0.6.5",


### PR DESCRIPTION
gulp-s3-upload had a dependency on event-stream, which has a dep of flatmap-stream - which contains malicious code.  They bumped their package to remove that dep, so I'm bumping this.