### PR TITLE
invalidateCloudfront task fix

### DIFF
--- a/config/gulp/tasks/deploy.js
+++ b/config/gulp/tasks/deploy.js
@@ -46,7 +46,7 @@ const invalidateCloudFront = cb => {
         }
     };
     const distroParams = [];
-    const promises = [];
+    const tasks = [];
 
     if (isArray(distroIds)) {
         distroIds.forEach(id => {
@@ -63,20 +63,24 @@ const invalidateCloudFront = cb => {
     }
 
     distroParams.forEach(distro => {
-        promises.push(
-            new Promise(() => {
+        const taskName = `invalidateCloudfront-${distro.DistributionId}`;
+        gulp.task(taskName, taskCb => {
+            return new Promise(() => {
                 cloudfront.createInvalidation(distro, (err, data) => {
                     if (err) {
                         throw new PluginError('invalidate', err, {showStack: true});
                     } else {
                         console.log(data); // eslint-disable-line no-console
+
+                        taskCb();
                     }
                 });
-            })
-        );
+            });
+        });
+        tasks.push(taskName);
     });
 
-    return Promise.all(promises).then(() => cb());
+    return sequence(tasks, cb);
 };
 
 const uploadToS3 = () => {

--- a/config/gulp/tasks/deploy.js
+++ b/config/gulp/tasks/deploy.js
@@ -64,6 +64,7 @@ const invalidateCloudFront = cb => {
 
     distroParams.forEach(distro => {
         const taskName = `invalidateCloudfront-${distro.DistributionId}`;
+
         gulp.task(taskName, taskCb => {
             return new Promise(() => {
                 cloudfront.createInvalidation(distro, (err, data) => {
@@ -77,10 +78,11 @@ const invalidateCloudFront = cb => {
                 });
             });
         });
+
         tasks.push(taskName);
     });
 
-    return sequence(tasks, cb);
+    sequence(tasks, cb);
 };
 
 const uploadToS3 = () => {

--- a/config/gulp/tasks/deploy.js
+++ b/config/gulp/tasks/deploy.js
@@ -70,15 +70,13 @@ const invalidateCloudFront = cb => {
                         throw new PluginError('invalidate', err, {showStack: true});
                     } else {
                         console.log(data); // eslint-disable-line no-console
-
-                        cb();
                     }
                 });
             })
         );
     });
 
-    return Promise.all(promises);
+    return Promise.all(promises).then(() => cb());
 };
 
 const uploadToS3 = () => {


### PR DESCRIPTION
fix: Move invalidateCloudfront callback to the return promise in order to fix the `task completion callback called too many times` error