### PR TITLE
feat: Support injected assets on deep route paths

### DIFF
--- a/config/webpack/client/config-prod.js
+++ b/config/webpack/client/config-prod.js
@@ -22,7 +22,7 @@ module.exports = {
     mode: 'production',
     devtool: settingsConfig.webpack.client.production.sourceMap,
     output: {
-        publicPath: `${settingsConfig.src.js.path}/`,
+        publicPath: `/${settingsConfig.src.js.path}/`,
     },
     plugins: [
         ...plugins,


### PR DESCRIPTION
This PR updates the production configuration to match the development configuration for output.publicPath. I propose this as a major breaking change.

Adding the leading slash to the output.publicPath allows generated assets that are injected to the head or body of the template via html-webpack-plugin to be relative to the base of the project rather than to the current directory.

Without the leading slash, when landing on deep paths such as `/some/path`, the injected assets would try to load from `/some/injectedAsset.js`. 

This StackOverflow post explains the issue nicely with a couple different options for handling it:
https://stackoverflow.com/questions/34620628/htmlwebpackplugin-injects-relative-path-files-which-breaks-when-loading-non-root

Setting [the base element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base#Anchor_elements), however, has implications for anchor links because it can cause a page refresh instead of a simple scroll.