### PR TITLE
feat: Enable passing options to htmlWebpackPlugin for use in template

### DIFF
--- a/config/settings.js
+++ b/config/settings.js
@@ -43,6 +43,7 @@ module.exports = {
             chunkFilename: '[name]-[chunkhash].js',
             output: '[name]-[hash].js',
             injectAssets: true,
+            injectOptions: {},
             alias: {},
             resolveModules: [],
             moduleRules: [],

--- a/config/webpack/client/config-common.js
+++ b/config/webpack/client/config-common.js
@@ -62,6 +62,7 @@ if (!isServer) {
         template: `${src}/${settingsConfig.src.index}`,
         inject: settingsConfig.webpack.client.injectAssets,
         aceEvent: process.env.ACE_NPM_EVENT,
+        ...settingsConfig.webpack.client.injectOptions
     }));
 }
 

--- a/docs/settings-webpack.md
+++ b/docs/settings-webpack.md
@@ -38,6 +38,9 @@ Whether to inject all assets into the given HTML template. If this is set to fal
 **default:**
 `true`
 
+### `injectOptions`
+Hook to pass in any other options supported by html-webpack-plugin. [Additional documentation](https://github.com/jantimon/html-webpack-plugin#options).
+
 ### `alias`
 An object to create aliases to `import` certain modules more easily. [Additional documentation](https://webpack.js.org/configuration/resolve/#resolve-alias).
 


### PR DESCRIPTION
htmlWebpackPlugin supports passing in variables which can then be used in the generated template. This allows us to use our project config to pass in our own variables, e.g. environment or page title, or any other option listed here: https://github.com/jantimon/html-webpack-plugin#options