### PR TITLE
Enable opt-out of browserSync

### DIFF
--- a/config/webpack/client/config-common.js
+++ b/config/webpack/client/config-common.js
@@ -33,7 +33,7 @@ const extraModules = settingsConfig.webpack.client.resolveModules.map(modulePath
     return path.resolve(`${src}/${modulePath}`);
 });
 const plugins = [
-    new WebpackAssetsManifest({
+    !settingsConfig.webpack.client.injectAssets && new WebpackAssetsManifest({
         output: `../${settingsConfig.dist.manifest.filename}`,
         writeToDisk: true,
         merge: true,
@@ -52,7 +52,7 @@ const plugins = [
             }
         }
     }),
-];
+].filter(Boolean);
 
 if (!isServer) {
     plugins.push(new HTMLWebpackPlugin({

--- a/config/webpack/client/config-dev.js
+++ b/config/webpack/client/config-dev.js
@@ -20,7 +20,7 @@ const plugins = [
             ...getEnvVars('development'),
         }
     }),
-    new BrowserSyncPlugin(
+    settingsConfig.browserSync && new BrowserSyncPlugin(
         {
             logPrefix: settingsConfig.browserSync.prefix,
             proxy: `http://${settingsConfig.env.hostname}:${settingsConfig.webpack.client.port}`,
@@ -35,7 +35,7 @@ const plugins = [
             reload: false
         }
     ),
-];
+].filter(Boolean);
 
 if (process.env.ACE_ENVIRONMENT === 'server') {
     files.push(`${dist}/${settingsConfig.webpack.server.output}`);

--- a/docs/settings-browsersync.md
+++ b/docs/settings-browsersync.md
@@ -4,6 +4,9 @@ title: Browsersync
 ---
 
 **key:** `browserSync`
+Optional.
+
+When included, browserSync can watch for changes in files not assocated with webpack (such as stylesheets compiled by a gulp task) and hot-reload the browser.
 
 ## `prefix`
 The prefix shown in shell when Browsersync events occur.

--- a/docs/settings-browsersync.md
+++ b/docs/settings-browsersync.md
@@ -6,7 +6,7 @@ title: Browsersync
 **key:** `browserSync`
 Optional.
 
-When included, browserSync can watch for changes in files not assocated with webpack (such as stylesheets compiled by a gulp task) and hot-reload the browser.
+When included, BrowserSync can watch for changes in files not associated with webpack (such as stylesheets compiled by a Gulp task) and inject them into browser.
 
 ## `prefix`
 The prefix shown in shell when Browsersync events occur.

--- a/docs/settings-browsersync.md
+++ b/docs/settings-browsersync.md
@@ -4,7 +4,7 @@ title: Browsersync
 ---
 
 **key:** `browserSync`
-When included, BrowserSync can watch for changes in files not associated with Webpack (such as stylesheets compiled by a Gulp task) and inject them into browser.
+When included, BrowserSync can watch for changes in files not associated with Webpack (such as stylesheets compiled by a Gulp task) and inject them into the browser.
 
 ## `prefix`
 The prefix shown in shell when Browsersync events occur.

--- a/docs/settings-browsersync.md
+++ b/docs/settings-browsersync.md
@@ -4,9 +4,7 @@ title: Browsersync
 ---
 
 **key:** `browserSync`
-Optional.
-
-When included, BrowserSync can watch for changes in files not associated with webpack (such as stylesheets compiled by a Gulp task) and inject them into browser.
+When included, BrowserSync can watch for changes in files not associated with Webpack (such as stylesheets compiled by a Gulp task) and inject them into browser.
 
 ## `prefix`
 The prefix shown in shell when Browsersync events occur.


### PR DESCRIPTION
BrowerSync, according to to the docs, is used primarily to facilitate CSS injection and hot reloading of styles when CSS is compiled by a SASS gulp task.

When using the `injectAssets: true` option provided through Ace along with a sass loader, CSS injection and reloading is handled by webpack without the need for BrowerSync.

This change is backwards-compatible because the `settingsConfig.browserSync` value was previously required. All existing projects would have it defined. By having this condition included in the new version, new projects can take advantage of the option to opt out of browerSync if it does not suit their needs.