### PR TITLE
Exit process on 'exit' event with pertinent code

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 const path = require('path');
+const process = require('process');
 
 const additionalArgs = require('minimist')(process.argv.slice(2))._;
 const aceEntryDir = path.resolve(__dirname, './config/gulp');
@@ -12,4 +13,6 @@ if (additionalArgs.length) {
     args = args.concat(additionalArgs);
 }
 
-require('child_process').fork(gulpBinaryFile, args);
+require('child_process')
+    .fork(gulpBinaryFile, args)
+    .on('exit', code => process.exit(code));


### PR DESCRIPTION
**Issue Link**: [CR-11184](https://spothero.atlassian.net/browse/CR-11184)

**Description**

Return the exit code from the forked Gulp process in order to handle ace errors externally.
