### PR TITLE
chore: http-proxy-middleware support for all options

### DIFF
--- a/config/gulp/server.js
+++ b/config/gulp/server.js
@@ -30,7 +30,7 @@ if (isDev) {
 
     // add local proxies for API requests
     forEach(settingsConfig.webpack.client.development.proxy, (value, key) => {
-        app.use(key, proxy({target: value}));
+        app.use(key, proxy(value));
     });
 
     app.use(errorhandler());


### PR DESCRIPTION
**Description**

In case each item in `settingsConfig.webpack.client.development.proxy` is a full object with [options](https://github.com/chimurai/http-proxy-middleware#http-proxy-options)

otherwise, it will work the same with the shorthand:
https://github.com/chimurai/http-proxy-middleware#createproxymiddlewareuri--config

This change would promote the alignment of how [devServer.proxy](https://webpack.js.org/configuration/dev-server/#devserverproxy) consumes the object