### PR TITLE
fix: Add eslint so eslint-loader works

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2585,6 +2585,77 @@
         "eslint-plugin-prettier": "3.1.0",
         "eslint-plugin-react": "7.14.3",
         "eslint-plugin-react-hooks": "2.0.1"
+      },
+      "dependencies": {
+        "eslint": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.3.0.tgz",
+          "integrity": "sha512-ZvZTKaqDue+N8Y9g0kp6UPZtS4FSY3qARxBs7p4f0H0iof381XHduqVerFWtK8DPtKmemqbqCFENWSQgPR/Gow==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "ajv": "^6.10.0",
+            "chalk": "^2.1.0",
+            "cross-spawn": "^6.0.5",
+            "debug": "^4.0.1",
+            "doctrine": "^3.0.0",
+            "eslint-scope": "^5.0.0",
+            "eslint-utils": "^1.4.2",
+            "eslint-visitor-keys": "^1.1.0",
+            "espree": "^6.1.1",
+            "esquery": "^1.0.1",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^5.0.1",
+            "functional-red-black-tree": "^1.0.1",
+            "glob-parent": "^5.0.0",
+            "globals": "^11.7.0",
+            "ignore": "^4.0.6",
+            "import-fresh": "^3.0.0",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^6.4.1",
+            "is-glob": "^4.0.0",
+            "js-yaml": "^3.13.1",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.3.0",
+            "lodash": "^4.17.14",
+            "minimatch": "^3.0.4",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.2",
+            "progress": "^2.0.0",
+            "regexpp": "^2.0.1",
+            "semver": "^6.1.2",
+            "strip-ansi": "^5.2.0",
+            "strip-json-comments": "^3.0.1",
+            "table": "^5.2.3",
+            "text-table": "^0.2.0",
+            "v8-compile-cache": "^2.0.3"
+          }
+        },
+        "inquirer": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+          "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+          "requires": {
+            "ansi-escapes": "^3.2.0",
+            "chalk": "^2.4.2",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^3.0.3",
+            "figures": "^2.0.0",
+            "lodash": "^4.17.12",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rxjs": "^6.4.0",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^5.1.0",
+            "through": "^2.3.6"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
       }
     },
     "@spothero/npm-publisher": {
@@ -3128,14 +3199,14 @@
       }
     },
     "acorn": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
     },
     "acorn-jsx": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
-      "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ=="
     },
     "acorn-walk": {
       "version": "6.2.0",
@@ -3312,6 +3383,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-3.2.0.tgz",
       "integrity": "sha1-nNnABpV+vpX62tW9YJiUKoE3N/Y=",
+      "optional": true,
       "requires": {
         "file-type": "^3.1.0"
       },
@@ -3319,7 +3391,8 @@
         "file-type": {
           "version": "3.9.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-          "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
+          "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
+          "optional": true
         }
       }
     },
@@ -3940,7 +4013,8 @@
         "map-obj": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "optional": true
         },
         "meow": {
           "version": "3.7.0",
@@ -3992,7 +4066,8 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "optional": true
         },
         "read-pkg": {
           "version": "1.1.0",
@@ -4108,6 +4183,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "optional": true,
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -4117,6 +4193,7 @@
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -4131,6 +4208,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -4496,6 +4574,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "optional": true,
       "requires": {
         "buffer-alloc-unsafe": "^1.1.0",
         "buffer-fill": "^1.0.0"
@@ -4504,7 +4583,8 @@
     "buffer-alloc-unsafe": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "optional": true
     },
     "buffer-crc32": {
       "version": "0.2.13",
@@ -4514,7 +4594,8 @@
     "buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+      "optional": true
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -4530,6 +4611,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-to-vinyl/-/buffer-to-vinyl-1.1.0.tgz",
       "integrity": "sha1-APFfruOreh3aLN5tkSG//dB7ImI=",
+      "optional": true,
       "requires": {
         "file-type": "^3.1.0",
         "readable-stream": "^2.0.2",
@@ -4540,12 +4622,14 @@
         "file-type": {
           "version": "3.9.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-          "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
+          "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
+          "optional": true
         },
         "readable-stream": {
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -4559,12 +4643,14 @@
         "replace-ext": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+          "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -4572,12 +4658,14 @@
         "uuid": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+          "optional": true
         },
         "vinyl": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+          "optional": true,
           "requires": {
             "clone": "^1.0.0",
             "clone-stats": "^0.0.1",
@@ -4762,7 +4850,8 @@
     "capture-stack-trace": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
-      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw=="
+      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
+      "optional": true
     },
     "caseless": {
       "version": "0.12.0",
@@ -4773,6 +4862,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/caw/-/caw-1.2.0.tgz",
       "integrity": "sha1-/7Im/n78VHKI3GLuPpcHPCEtEDQ=",
+      "optional": true,
       "requires": {
         "get-proxy": "^1.0.1",
         "is-obj": "^1.0.0",
@@ -4783,12 +4873,14 @@
         "object-assign": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+          "optional": true
         },
         "tunnel-agent": {
           "version": "0.4.3",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+          "optional": true
         }
       }
     },
@@ -5128,7 +5220,8 @@
     "co": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
-      "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g="
+      "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g=",
+      "optional": true
     },
     "coa": {
       "version": "2.0.2",
@@ -5678,6 +5771,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "optional": true,
       "requires": {
         "capture-stack-trace": "^1.0.0"
       }
@@ -6106,6 +6200,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/decompress/-/decompress-3.0.0.tgz",
       "integrity": "sha1-rx3VDQbjv8QyRh033hGzjA2ZG+0=",
+      "optional": true,
       "requires": {
         "buffer-to-vinyl": "^1.0.0",
         "concat-stream": "^1.4.6",
@@ -6122,6 +6217,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "optional": true,
           "requires": {
             "arr-flatten": "^1.0.1"
           }
@@ -6129,12 +6225,14 @@
         "array-unique": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "optional": true
         },
         "braces": {
           "version": "1.8.5",
           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "optional": true,
           "requires": {
             "expand-range": "^1.8.1",
             "preserve": "^0.2.0",
@@ -6145,6 +6243,7 @@
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "optional": true,
           "requires": {
             "is-posix-bracket": "^0.1.0"
           }
@@ -6153,6 +6252,7 @@
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           },
@@ -6160,7 +6260,8 @@
             "is-extglob": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+              "optional": true
             }
           }
         },
@@ -6168,6 +6269,7 @@
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "optional": true,
           "requires": {
             "inflight": "^1.0.4",
             "inherits": "2",
@@ -6180,6 +6282,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "optional": true,
           "requires": {
             "is-glob": "^3.1.0",
             "path-dirname": "^1.0.0"
@@ -6189,6 +6292,7 @@
           "version": "5.3.5",
           "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
           "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+          "optional": true,
           "requires": {
             "extend": "^3.0.0",
             "glob": "^5.0.3",
@@ -6203,12 +6307,14 @@
             "isarray": {
               "version": "0.0.1",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+              "optional": true
             },
             "readable-stream": {
               "version": "1.0.34",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+              "optional": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.1",
@@ -6219,12 +6325,14 @@
             "string_decoder": {
               "version": "0.10.31",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+              "optional": true
             },
             "through2": {
               "version": "0.6.5",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
               "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+              "optional": true,
               "requires": {
                 "readable-stream": ">=1.0.33-1 <1.1.0-0",
                 "xtend": ">=4.0.0 <4.1.0-0"
@@ -6236,6 +6344,7 @@
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
           "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+          "optional": true,
           "requires": {
             "convert-source-map": "^1.1.1",
             "graceful-fs": "^4.1.2",
@@ -6248,6 +6357,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "optional": true,
           "requires": {
             "is-extglob": "^2.1.0"
           }
@@ -6256,6 +6366,7 @@
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -6264,6 +6375,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
           "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+          "optional": true,
           "requires": {
             "readable-stream": "^2.0.1"
           }
@@ -6272,6 +6384,7 @@
           "version": "2.3.11",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "optional": true,
           "requires": {
             "arr-diff": "^2.0.0",
             "array-unique": "^0.2.1",
@@ -6291,12 +6404,14 @@
             "is-extglob": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+              "optional": true
             },
             "is-glob": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+              "optional": true,
               "requires": {
                 "is-extglob": "^1.0.0"
               }
@@ -6307,6 +6422,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "optional": true,
           "requires": {
             "remove-trailing-separator": "^1.0.1"
           }
@@ -6315,6 +6431,7 @@
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
           "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+          "optional": true,
           "requires": {
             "is-stream": "^1.0.1",
             "readable-stream": "^2.0.1"
@@ -6324,6 +6441,7 @@
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -6337,12 +6455,14 @@
         "replace-ext": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+          "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -6351,6 +6471,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "optional": true,
           "requires": {
             "is-utf8": "^0.2.0"
           }
@@ -6359,6 +6480,7 @@
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "optional": true,
           "requires": {
             "readable-stream": "~2.3.6",
             "xtend": "~4.0.1"
@@ -6368,6 +6490,7 @@
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
           "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
+          "optional": true,
           "requires": {
             "json-stable-stringify-without-jsonify": "^1.0.1",
             "through2-filter": "^3.0.0"
@@ -6377,6 +6500,7 @@
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
               "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
+              "optional": true,
               "requires": {
                 "through2": "~2.0.0",
                 "xtend": "~4.0.0"
@@ -6388,6 +6512,7 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+          "optional": true,
           "requires": {
             "clone": "^1.0.0",
             "clone-stats": "^0.0.1",
@@ -6398,6 +6523,7 @@
           "version": "2.4.4",
           "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
           "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+          "optional": true,
           "requires": {
             "duplexify": "^3.2.0",
             "glob-stream": "^5.3.2",
@@ -6424,6 +6550,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
       "integrity": "sha1-IXx4n5uURQ76rcXF5TeXj8MzxGY=",
+      "optional": true,
       "requires": {
         "is-tar": "^1.0.0",
         "object-assign": "^2.0.0",
@@ -6436,22 +6563,26 @@
         "clone": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
+          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+          "optional": true
         },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "optional": true
         },
         "object-assign": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
+          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
+          "optional": true
         },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.1",
@@ -6462,12 +6593,14 @@
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "optional": true
         },
         "through2": {
           "version": "0.6.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "optional": true,
           "requires": {
             "readable-stream": ">=1.0.33-1 <1.1.0-0",
             "xtend": ">=4.0.0 <4.1.0-0"
@@ -6477,6 +6610,7 @@
           "version": "0.4.6",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+          "optional": true,
           "requires": {
             "clone": "^0.2.0",
             "clone-stats": "^0.0.1"
@@ -6488,6 +6622,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
       "integrity": "sha1-iyOTVoE1X58YnYclag+L3ZbZZm0=",
+      "optional": true,
       "requires": {
         "is-bzip2": "^1.0.0",
         "object-assign": "^2.0.0",
@@ -6501,22 +6636,26 @@
         "clone": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
+          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+          "optional": true
         },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "optional": true
         },
         "object-assign": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
+          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
+          "optional": true
         },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.1",
@@ -6527,12 +6666,14 @@
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "optional": true
         },
         "through2": {
           "version": "0.6.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "optional": true,
           "requires": {
             "readable-stream": ">=1.0.33-1 <1.1.0-0",
             "xtend": ">=4.0.0 <4.1.0-0"
@@ -6542,6 +6683,7 @@
           "version": "0.4.6",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+          "optional": true,
           "requires": {
             "clone": "^0.2.0",
             "clone-stats": "^0.0.1"
@@ -6553,6 +6695,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
       "integrity": "sha1-ssE9+YFmJomRtxXWRH9kLpaW9aA=",
+      "optional": true,
       "requires": {
         "is-gzip": "^1.0.0",
         "object-assign": "^2.0.0",
@@ -6565,22 +6708,26 @@
         "clone": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
+          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+          "optional": true
         },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "optional": true
         },
         "object-assign": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
+          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
+          "optional": true
         },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.1",
@@ -6591,12 +6738,14 @@
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "optional": true
         },
         "through2": {
           "version": "0.6.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "optional": true,
           "requires": {
             "readable-stream": ">=1.0.33-1 <1.1.0-0",
             "xtend": ">=4.0.0 <4.1.0-0"
@@ -6606,6 +6755,7 @@
           "version": "0.4.6",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+          "optional": true,
           "requires": {
             "clone": "^0.2.0",
             "clone-stats": "^0.0.1"
@@ -6617,6 +6767,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.4.0.tgz",
       "integrity": "sha1-YUdbQVIGa74/7hL51inRX+ZHjus=",
+      "optional": true,
       "requires": {
         "is-zip": "^1.0.0",
         "read-all-stream": "^3.0.0",
@@ -6631,6 +6782,7 @@
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -6644,12 +6796,14 @@
         "replace-ext": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+          "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -6658,6 +6812,7 @@
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "optional": true,
           "requires": {
             "readable-stream": "~2.3.6",
             "xtend": "~4.0.1"
@@ -6667,6 +6822,7 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+          "optional": true,
           "requires": {
             "clone": "^1.0.0",
             "clone-stats": "^0.0.1",
@@ -7044,6 +7200,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/download/-/download-4.4.3.tgz",
       "integrity": "sha1-qlX9rTktldS2jowr4D4MKqIbqaw=",
+      "optional": true,
       "requires": {
         "caw": "^1.0.1",
         "concat-stream": "^1.4.7",
@@ -7066,6 +7223,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "optional": true,
           "requires": {
             "arr-flatten": "^1.0.1"
           }
@@ -7073,12 +7231,14 @@
         "array-unique": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "optional": true
         },
         "braces": {
           "version": "1.8.5",
           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "optional": true,
           "requires": {
             "expand-range": "^1.8.1",
             "preserve": "^0.2.0",
@@ -7089,6 +7249,7 @@
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "optional": true,
           "requires": {
             "is-posix-bracket": "^0.1.0"
           }
@@ -7097,6 +7258,7 @@
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           },
@@ -7104,7 +7266,8 @@
             "is-extglob": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+              "optional": true
             }
           }
         },
@@ -7112,6 +7275,7 @@
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "optional": true,
           "requires": {
             "inflight": "^1.0.4",
             "inherits": "2",
@@ -7124,6 +7288,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "optional": true,
           "requires": {
             "is-glob": "^3.1.0",
             "path-dirname": "^1.0.0"
@@ -7133,6 +7298,7 @@
           "version": "5.3.5",
           "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
           "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+          "optional": true,
           "requires": {
             "extend": "^3.0.0",
             "glob": "^5.0.3",
@@ -7147,12 +7313,14 @@
             "isarray": {
               "version": "0.0.1",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+              "optional": true
             },
             "readable-stream": {
               "version": "1.0.34",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+              "optional": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.1",
@@ -7163,12 +7331,14 @@
             "string_decoder": {
               "version": "0.10.31",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+              "optional": true
             },
             "through2": {
               "version": "0.6.5",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
               "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+              "optional": true,
               "requires": {
                 "readable-stream": ">=1.0.33-1 <1.1.0-0",
                 "xtend": ">=4.0.0 <4.1.0-0"
@@ -7180,6 +7350,7 @@
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
           "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+          "optional": true,
           "requires": {
             "convert-source-map": "^1.1.1",
             "graceful-fs": "^4.1.2",
@@ -7192,6 +7363,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "optional": true,
           "requires": {
             "is-extglob": "^2.1.0"
           }
@@ -7200,6 +7372,7 @@
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -7208,6 +7381,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
           "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+          "optional": true,
           "requires": {
             "readable-stream": "^2.0.1"
           }
@@ -7216,6 +7390,7 @@
           "version": "2.3.11",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "optional": true,
           "requires": {
             "arr-diff": "^2.0.0",
             "array-unique": "^0.2.1",
@@ -7235,12 +7410,14 @@
             "is-extglob": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+              "optional": true
             },
             "is-glob": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+              "optional": true,
               "requires": {
                 "is-extglob": "^1.0.0"
               }
@@ -7251,6 +7428,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "optional": true,
           "requires": {
             "remove-trailing-separator": "^1.0.1"
           }
@@ -7259,6 +7437,7 @@
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
           "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+          "optional": true,
           "requires": {
             "is-stream": "^1.0.1",
             "readable-stream": "^2.0.1"
@@ -7268,6 +7447,7 @@
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -7281,12 +7461,14 @@
         "replace-ext": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+          "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -7295,6 +7477,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "optional": true,
           "requires": {
             "is-utf8": "^0.2.0"
           }
@@ -7303,6 +7486,7 @@
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "optional": true,
           "requires": {
             "readable-stream": "~2.3.6",
             "xtend": "~4.0.1"
@@ -7312,6 +7496,7 @@
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
           "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
+          "optional": true,
           "requires": {
             "json-stable-stringify-without-jsonify": "^1.0.1",
             "through2-filter": "^3.0.0"
@@ -7321,6 +7506,7 @@
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
               "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
+              "optional": true,
               "requires": {
                 "through2": "~2.0.0",
                 "xtend": "~4.0.0"
@@ -7332,6 +7518,7 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+          "optional": true,
           "requires": {
             "clone": "^1.0.0",
             "clone-stats": "^0.0.1",
@@ -7342,6 +7529,7 @@
           "version": "2.4.4",
           "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
           "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+          "optional": true,
           "requires": {
             "duplexify": "^3.2.0",
             "glob-stream": "^5.3.2",
@@ -7447,6 +7635,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
       "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
+      "optional": true,
       "requires": {
         "onetime": "^1.0.0",
         "set-immediate-shim": "^1.0.0"
@@ -7455,7 +7644,8 @@
         "onetime": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+          "optional": true
         }
       }
     },
@@ -7762,9 +7952,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.3.0.tgz",
-      "integrity": "sha512-ZvZTKaqDue+N8Y9g0kp6UPZtS4FSY3qARxBs7p4f0H0iof381XHduqVerFWtK8DPtKmemqbqCFENWSQgPR/Gow==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -7773,19 +7963,19 @@
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
         "eslint-scope": "^5.0.0",
-        "eslint-utils": "^1.4.2",
+        "eslint-utils": "^1.4.3",
         "eslint-visitor-keys": "^1.1.0",
-        "espree": "^6.1.1",
+        "espree": "^6.1.2",
         "esquery": "^1.0.1",
         "esutils": "^2.0.2",
         "file-entry-cache": "^5.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
-        "globals": "^11.7.0",
+        "globals": "^12.1.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^6.4.1",
+        "inquirer": "^7.0.0",
         "is-glob": "^4.0.0",
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
@@ -7794,7 +7984,7 @@
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
+        "optionator": "^0.8.3",
         "progress": "^2.0.0",
         "regexpp": "^2.0.1",
         "semver": "^6.1.2",
@@ -7805,24 +7995,12 @@
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
-        "inquirer": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
-          "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
           "requires": {
-            "ansi-escapes": "^3.2.0",
-            "chalk": "^2.4.2",
-            "cli-cursor": "^2.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^3.0.3",
-            "figures": "^2.0.0",
-            "lodash": "^4.17.12",
-            "mute-stream": "0.0.7",
-            "run-async": "^2.2.0",
-            "rxjs": "^6.4.0",
-            "string-width": "^2.1.0",
-            "strip-ansi": "^5.1.0",
-            "through": "^2.3.6"
+            "type-fest": "^0.8.1"
           }
         },
         "semver": {
@@ -8004,12 +8182,12 @@
       "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A=="
     },
     "espree": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
-      "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
       "requires": {
-        "acorn": "^7.1.0",
-        "acorn-jsx": "^5.1.0",
+        "acorn": "^7.1.1",
+        "acorn-jsx": "^5.2.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
@@ -8019,11 +8197,18 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.2.0.tgz",
+      "integrity": "sha512-weltsSqdeWIX9G2qQZz7KlTRJdkkOCTPgLYJUz1Hacf48R4YOwGPHO3+ORfWedqJKbq5WQmsgK90n+pFLIKt/Q==",
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "^5.0.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.0.0.tgz",
+          "integrity": "sha512-j3acdrMzqrxmJTNj5dbr1YbjacrYgAxVMeF0gK16E3j494mOe7xygM/ZLIguEQ0ETwAg2hlJCtHRGav+y0Ny5A=="
+        }
       }
     },
     "esrecurse": {
@@ -8256,6 +8441,7 @@
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "optional": true,
       "requires": {
         "fill-range": "^2.1.0"
       },
@@ -8264,6 +8450,7 @@
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
           "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+          "optional": true,
           "requires": {
             "is-number": "^2.1.0",
             "isobject": "^2.0.0",
@@ -8276,6 +8463,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           }
@@ -8284,6 +8472,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
           "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "optional": true,
           "requires": {
             "isarray": "1.0.0"
           }
@@ -8292,6 +8481,7 @@
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -8697,17 +8887,20 @@
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+      "optional": true
     },
     "filename-reserved-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
-      "integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q="
+      "integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q=",
+      "optional": true
     },
     "filenamify": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
       "integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
+      "optional": true,
       "requires": {
         "filename-reserved-regex": "^1.0.0",
         "strip-outer": "^1.0.0",
@@ -8833,7 +9026,8 @@
         "get-stdin": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+          "optional": true
         },
         "indent-string": {
           "version": "2.1.0",
@@ -8860,7 +9054,8 @@
         "map-obj": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "optional": true
         },
         "meow": {
           "version": "3.7.0",
@@ -8912,7 +9107,8 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "optional": true
         },
         "read-pkg": {
           "version": "1.1.0",
@@ -9192,7 +9388,8 @@
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "optional": true
     },
     "fs-extra": {
       "version": "3.0.1",
@@ -9269,7 +9466,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -9287,11 +9485,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9304,15 +9504,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9415,7 +9618,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9425,6 +9629,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9437,17 +9642,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -9464,6 +9672,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9536,7 +9745,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9546,6 +9756,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9621,7 +9832,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9651,6 +9863,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9668,6 +9881,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9706,11 +9920,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -9818,6 +10034,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.1.0.tgz",
       "integrity": "sha1-iUhUSRvFkbDxR9euVw9cZ4tyVus=",
+      "optional": true,
       "requires": {
         "rc": "^1.1.2"
       }
@@ -10036,6 +10253,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "optional": true,
       "requires": {
         "glob-parent": "^2.0.0",
         "is-glob": "^2.0.0"
@@ -10045,6 +10263,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "optional": true,
           "requires": {
             "is-glob": "^2.0.0"
           }
@@ -10052,12 +10271,14 @@
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -10305,6 +10526,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
       "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
+      "optional": true,
       "requires": {
         "create-error-class": "^3.0.1",
         "duplexer2": "^0.1.4",
@@ -10327,6 +10549,7 @@
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+          "optional": true,
           "requires": {
             "readable-stream": "^2.0.2"
           }
@@ -10335,6 +10558,7 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "optional": true,
           "requires": {
             "error-ex": "^1.2.0"
           }
@@ -10343,6 +10567,7 @@
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -10357,6 +10582,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -10371,7 +10597,8 @@
     "graceful-readlink": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "optional": true
     },
     "growly": {
       "version": "1.3.0",
@@ -10444,6 +10671,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.2.0.tgz",
       "integrity": "sha1-jutlpeAV+O2FMsr+KEVJYGJvDcc=",
+      "optional": true,
       "requires": {
         "archive-type": "^3.0.0",
         "decompress": "^3.0.0",
@@ -10455,6 +10683,7 @@
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -10469,6 +10698,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -12248,7 +12478,8 @@
     "is-bzip2": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz",
-      "integrity": "sha1-XuWOqlounIDiFAe+3yOuWsCRs/w="
+      "integrity": "sha1-XuWOqlounIDiFAe+3yOuWsCRs/w=",
+      "optional": true
     },
     "is-callable": {
       "version": "1.1.4",
@@ -12329,12 +12560,14 @@
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+      "optional": true
     },
     "is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "optional": true,
       "requires": {
         "is-primitive": "^2.0.0"
       }
@@ -12379,7 +12612,8 @@
     "is-gzip": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
-      "integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM="
+      "integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM=",
+      "optional": true
     },
     "is-hexadecimal": {
       "version": "1.0.4",
@@ -12404,7 +12638,8 @@
     "is-natural-number": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.1.1.tgz",
-      "integrity": "sha1-fUxXKDd+84bD4ZSpkRv1fG3DNec="
+      "integrity": "sha1-fUxXKDd+84bD4ZSpkRv1fG3DNec=",
+      "optional": true
     },
     "is-number": {
       "version": "3.0.0",
@@ -12490,12 +12725,14 @@
     "is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "optional": true
     },
     "is-primitive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "optional": true
     },
     "is-promise": {
       "version": "2.1.0",
@@ -12505,7 +12742,8 @@
     "is-redirect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+      "optional": true
     },
     "is-regex": {
       "version": "1.0.4",
@@ -12536,7 +12774,8 @@
     "is-retry-allowed": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
+      "optional": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -12562,7 +12801,8 @@
     "is-tar": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz",
-      "integrity": "sha1-L2suF5LB9bs2UZrKqdZcDSb+hT0="
+      "integrity": "sha1-L2suF5LB9bs2UZrKqdZcDSb+hT0=",
+      "optional": true
     },
     "is-text-path": {
       "version": "1.0.1",
@@ -12589,7 +12829,8 @@
     "is-url": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "optional": true
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -12599,7 +12840,8 @@
     "is-valid-glob": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
-      "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4="
+      "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
+      "optional": true
     },
     "is-whitespace-character": {
       "version": "1.0.4",
@@ -12624,7 +12866,8 @@
     "is-zip": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz",
-      "integrity": "sha1-R7Co/004p2QxzP2ZqOFaTIa6IyU="
+      "integrity": "sha1-R7Co/004p2QxzP2ZqOFaTIa6IyU=",
+      "optional": true
     },
     "isarray": {
       "version": "1.0.0",
@@ -12837,6 +13080,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+      "optional": true,
       "requires": {
         "readable-stream": "^2.0.5"
       },
@@ -12845,6 +13089,7 @@
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -12859,6 +13104,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -13504,7 +13750,8 @@
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "optional": true
     },
     "lodash.isfinite": {
       "version": "3.3.2",
@@ -13675,7 +13922,8 @@
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "optional": true
     },
     "lpad-align": {
       "version": "1.1.2",
@@ -13718,12 +13966,14 @@
         "get-stdin": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+          "optional": true
         },
         "indent-string": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+          "optional": true,
           "requires": {
             "repeating": "^2.0.0"
           }
@@ -13744,7 +13994,8 @@
         "map-obj": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "optional": true
         },
         "meow": {
           "version": "3.7.0",
@@ -13796,7 +14047,8 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "optional": true
         },
         "read-pkg": {
           "version": "1.1.0",
@@ -13926,7 +14178,8 @@
     "math-random": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
-      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A=="
+      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
+      "optional": true
     },
     "mathml-tag-names": {
       "version": "2.1.3",
@@ -14888,7 +15141,8 @@
     "node-status-codes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
-      "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8="
+      "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
+      "optional": true
     },
     "node.extend": {
       "version": "2.0.2",
@@ -15122,6 +15376,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "optional": true,
       "requires": {
         "for-own": "^0.1.4",
         "is-extendable": "^0.1.1"
@@ -15131,6 +15386,7 @@
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
           "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+          "optional": true,
           "requires": {
             "for-in": "^1.0.1"
           }
@@ -15553,6 +15809,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "optional": true,
       "requires": {
         "glob-base": "^0.3.0",
         "is-dotfile": "^1.0.0",
@@ -15563,12 +15820,14 @@
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -16522,7 +16781,8 @@
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "optional": true
     },
     "prettier": {
       "version": "1.18.2",
@@ -16729,6 +16989,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
       "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+      "optional": true,
       "requires": {
         "is-number": "^4.0.0",
         "kind-of": "^6.0.0",
@@ -16738,7 +16999,8 @@
         "is-number": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "optional": true
         }
       }
     },
@@ -16802,6 +17064,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
       "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
+      "optional": true,
       "requires": {
         "pinkie-promise": "^2.0.0",
         "readable-stream": "^2.0.0"
@@ -16811,6 +17074,7 @@
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -16825,6 +17089,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -17002,6 +17267,7 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "optional": true,
       "requires": {
         "is-equal-shallow": "^0.1.3"
       }
@@ -17863,6 +18129,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
+      "optional": true,
       "requires": {
         "commander": "~2.8.1"
       },
@@ -17871,6 +18138,7 @@
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+          "optional": true,
           "requires": {
             "graceful-readlink": ">= 1.0.0"
           }
@@ -18066,7 +18334,8 @@
     "set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+      "optional": true
     },
     "set-value": {
       "version": "2.0.1",
@@ -18887,7 +19156,8 @@
     "stat-mode": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
-      "integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI="
+      "integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI=",
+      "optional": true
     },
     "state-toggle": {
       "version": "1.0.3",
@@ -18995,6 +19265,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
       "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
+      "optional": true,
       "requires": {
         "duplexer2": "~0.1.0",
         "readable-stream": "^2.0.2"
@@ -19004,6 +19275,7 @@
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+          "optional": true,
           "requires": {
             "readable-stream": "^2.0.2"
           }
@@ -19012,6 +19284,7 @@
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -19026,6 +19299,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -19230,6 +19504,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
       "integrity": "sha1-lgu9EoeETzl1pFWKoQOoJV4kVqA=",
+      "optional": true,
       "requires": {
         "chalk": "^1.0.0",
         "get-stdin": "^4.0.1",
@@ -19242,17 +19517,20 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "optional": true
         },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "optional": true
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "optional": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -19264,12 +19542,14 @@
         "get-stdin": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+          "optional": true
         },
         "is-absolute": {
           "version": "0.1.7",
           "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
           "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
+          "optional": true,
           "requires": {
             "is-relative": "^0.1.0"
           }
@@ -19277,12 +19557,14 @@
         "is-relative": {
           "version": "0.1.3",
           "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
-          "integrity": "sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI="
+          "integrity": "sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI=",
+          "optional": true
         },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -19290,7 +19572,8 @@
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "optional": true
         }
       }
     },
@@ -19305,14 +19588,15 @@
       "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
     },
     "strip-json-comments": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-      "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
+      "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w=="
     },
     "strip-outer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
       "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "optional": true,
       "requires": {
         "escape-string-regexp": "^1.0.2"
       }
@@ -19403,6 +19687,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz",
       "integrity": "sha1-HGYfZnBX9jvLeHWqFDi8FiUlFW4=",
+      "optional": true,
       "requires": {
         "chalk": "^1.0.0"
       },
@@ -19410,17 +19695,20 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "optional": true
         },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "optional": true
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "optional": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -19433,6 +19721,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -19440,7 +19729,8 @@
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "optional": true
         }
       }
     },
@@ -19531,6 +19821,7 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
       "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+      "optional": true,
       "requires": {
         "bl": "^1.0.0",
         "buffer-alloc": "^1.2.0",
@@ -19545,6 +19836,7 @@
           "version": "1.4.4",
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
           "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+          "optional": true,
           "requires": {
             "once": "^1.4.0"
           }
@@ -19553,6 +19845,7 @@
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -19567,6 +19860,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -19809,6 +20103,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
       "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+      "optional": true,
       "requires": {
         "through2": "~2.0.0",
         "xtend": "~4.0.0"
@@ -19818,6 +20113,7 @@
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -19832,6 +20128,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -19840,6 +20137,7 @@
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "optional": true,
           "requires": {
             "readable-stream": "~2.3.6",
             "xtend": "~4.0.1"
@@ -19868,7 +20166,8 @@
     "timed-out": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
-      "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc="
+      "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=",
+      "optional": true
     },
     "timers-browserify": {
       "version": "2.0.11",
@@ -19895,6 +20194,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
       "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
+      "optional": true,
       "requires": {
         "extend-shallow": "^2.0.1"
       },
@@ -19903,6 +20203,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -19922,7 +20223,8 @@
     "to-buffer": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+      "optional": true
     },
     "to-fast-properties": {
       "version": "2.0.0",
@@ -20013,6 +20315,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+      "optional": true,
       "requires": {
         "escape-string-regexp": "^1.0.2"
       }
@@ -20331,7 +20634,8 @@
     "unzip-response": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
+      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
+      "optional": true
     },
     "upath": {
       "version": "1.2.0",
@@ -20385,6 +20689,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "optional": true,
       "requires": {
         "prepend-http": "^1.0.1"
       }
@@ -20497,7 +20802,8 @@
     "vali-date": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
-      "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY="
+      "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
+      "optional": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -20594,6 +20900,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.1.tgz",
       "integrity": "sha1-TRmIkbVRWRHXcajNnFSApGoHSkU=",
+      "optional": true,
       "requires": {
         "object-assign": "^4.0.1",
         "readable-stream": "^2.0.0"
@@ -20603,6 +20910,7 @@
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -20617,6 +20925,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -20826,6 +21135,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
       "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
+      "optional": true,
       "requires": {
         "wrap-fn": "^0.1.0"
       }
@@ -21790,6 +22100,7 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz",
       "integrity": "sha1-8htuQQFv9KfjFyDbxjoJAWvfmEU=",
+      "optional": true,
       "requires": {
         "co": "3.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "del": "5.1.0",
     "diff": "4.0.1",
     "errorhandler": "1.5.1",
+    "eslint": "6.8.0",
     "eslint-friendly-formatter": "4.0.1",
     "eslint-loader": "3.0.3",
     "express": "4.17.1",


### PR DESCRIPTION
**Description**
I tried upgrading ACE for control panel and got an error:
```
ERROR in /home/seth/git/control-panel/src/js/main.js
Module build failed (from /home/seth/git/control-panel/node_modules/eslint-loader/dist/cjs.js):
Error: Cannot find module 'eslint'
```
Then saw the *note* on this page: https://webpack.js.org/loaders/eslint-loader/