### PR TITLE
fix: Set context for Stylelint plugin

### DIFF
--- a/config/webpack/client/config-common.js
+++ b/config/webpack/client/config-common.js
@@ -71,7 +71,7 @@ const plugins = [
         filename: isDev ? '[name].css' : '[name]-[hash].css',
     }),
     new StylelintPlugin({
-        context: path.resolve(`${src}`),
+        context: src,
     }),
 ].filter(Boolean);
 

--- a/config/webpack/client/config-common.js
+++ b/config/webpack/client/config-common.js
@@ -70,7 +70,9 @@ const plugins = [
     new MiniCssExtractPlugin({
         filename: isDev ? '[name].css' : '[name]-[hash].css',
     }),
-    new StylelintPlugin(),
+    new StylelintPlugin({
+        context: path.resolve(`${src}`),
+    }),
 ].filter(Boolean);
 
 if (!isServer) {


### PR DESCRIPTION
**Issue Link**
<!-- Link to the Jira ticket or GitHub issue -->

**Description**
- It stops builds.
- I set it to src instead of src/sass since dev portal has sass files in other folders.
