### PR TITLE
fix: Re-organize server file output and fix publicPath settings

### DIFF
--- a/config/webpack/client/config-common.js
+++ b/config/webpack/client/config-common.js
@@ -93,6 +93,7 @@ const config = {
     entry,
     output: {
         path: path.resolve(`${dist}`),
+        publicPath: '/',
         filename: settingsConfig.webpack.client.output,
         chunkFilename: settingsConfig.webpack.client.chunkFilename,
     },

--- a/config/webpack/client/config-dev.js
+++ b/config/webpack/client/config-dev.js
@@ -61,9 +61,6 @@ if (analyze) {
 module.exports = {
     mode: 'development',
     devtool: settingsConfig.webpack.client.development.sourceMap,
-    output: {
-        publicPath: '/',
-    },
     plugins: [...plugins, ...settingsConfig.webpack.client.development.plugins],
     optimization: {
         noEmitOnErrors: true,

--- a/config/webpack/client/config-dev.js
+++ b/config/webpack/client/config-dev.js
@@ -62,7 +62,7 @@ module.exports = {
     mode: 'development',
     devtool: settingsConfig.webpack.client.development.sourceMap,
     output: {
-        publicPath: `/${settingsConfig.src.js.path}/`,
+        publicPath: '/',
     },
     plugins: [...plugins, ...settingsConfig.webpack.client.development.plugins],
     optimization: {

--- a/config/webpack/client/config-prod.js
+++ b/config/webpack/client/config-prod.js
@@ -22,9 +22,6 @@ if (analyze) {
 module.exports = {
     mode: 'production',
     devtool: settingsConfig.webpack.client.production.sourceMap,
-    output: {
-        publicPath: '/',
-    },
     plugins: [...plugins, ...settingsConfig.webpack.client.production.plugins],
     performance: {
         hints: false,

--- a/config/webpack/client/config-prod.js
+++ b/config/webpack/client/config-prod.js
@@ -23,7 +23,7 @@ module.exports = {
     mode: 'production',
     devtool: settingsConfig.webpack.client.production.sourceMap,
     output: {
-        publicPath: `/${settingsConfig.src.js.path}/`,
+        publicPath: '/',
     },
     plugins: [...plugins, ...settingsConfig.webpack.client.production.plugins],
     performance: {

--- a/config/webpack/client/config-test.js
+++ b/config/webpack/client/config-test.js
@@ -48,9 +48,6 @@ if (process.env.ACE_ENVIRONMENT === 'server') {
 module.exports = {
     mode: 'development',
     devtool: settingsConfig.webpack.client.test.sourceMap,
-    output: {
-        publicPath: '/',
-    },
     cache: true,
     plugins: [...plugins, ...settingsConfig.webpack.client.test.plugins],
     optimization: {

--- a/config/webpack/client/config-test.js
+++ b/config/webpack/client/config-test.js
@@ -49,7 +49,7 @@ module.exports = {
     mode: 'development',
     devtool: settingsConfig.webpack.client.test.sourceMap,
     output: {
-        publicPath: `/${settingsConfig.src.js.path}/`,
+        publicPath: '/',
     },
     cache: true,
     plugins: [...plugins, ...settingsConfig.webpack.client.test.plugins],

--- a/config/webpack/server/config-common.js
+++ b/config/webpack/server/config-common.js
@@ -22,7 +22,7 @@ const config = {
     target: 'node',
     entry: `${src}/${settingsConfig.webpack.server.entry}`,
     output: {
-        path: `${dist}/${settingsConfig.src.js.path}`,
+        path: dist,
         filename: settingsConfig.webpack.server.output,
         libraryTarget: 'commonjs2',
     },

--- a/config/webpack/server/config-common.js
+++ b/config/webpack/server/config-common.js
@@ -22,7 +22,7 @@ const config = {
     target: 'node',
     entry: `${src}/${settingsConfig.webpack.server.entry}`,
     output: {
-        path: dist,
+        path: `${dist}/${settingsConfig.src.js.path}`,
         filename: settingsConfig.webpack.server.output,
         libraryTarget: 'commonjs2',
     },


### PR DESCRIPTION
**Issue Link**
<!-- Link to the Jira ticket or GitHub issue -->

**Description**
- Server files were being output straight into /dist. Fixed by adding /js to output setting
- All files had an additional /js appended to the front. Fixed by removing /js from publicPath settings