### PR TITLE
feat: Adding cssLoaderOptions to extend css-loader

### DIFF
--- a/config/webpack/client/config-common.js
+++ b/config/webpack/client/config-common.js
@@ -72,7 +72,7 @@ const plugins = [
     }),
     new StylelintPlugin({
         context: src,
-        emitWarning: isDev
+        emitWarning: isDev,
     }),
 ].filter(Boolean);
 
@@ -114,13 +114,12 @@ const config = {
                 test: /\.scss$/,
                 exclude: /\.module\.scss$/,
                 use: [
-                    {
-                        loader: MiniCssExtractPlugin.loader,
-                    },
+                    MiniCssExtractPlugin.loader,
                     {
                         loader: 'css-loader',
                         options: {
                             sourceMap: isDev,
+                            ...settingsConfig.webpack.client.cssLoaderOptions,
                         },
                     },
                     {
@@ -159,7 +158,7 @@ const config = {
                 ],
             },
             {
-                test: /\.(png|svg|jpg|gif)$/,
+                test: /\.(png|svg|jpe?g|gif)$/,
                 loader: 'file-loader',
                 options: {
                     outputPath: 'img',

--- a/config/webpack/client/config-common.js
+++ b/config/webpack/client/config-common.js
@@ -114,7 +114,12 @@ const config = {
                 test: /\.scss$/,
                 exclude: /\.module\.scss$/,
                 use: [
-                    MiniCssExtractPlugin.loader,
+                    {
+                        loader: MiniCssExtractPlugin.loader,
+                        options: {
+                            hmr: isDev
+                        }
+                    },
                     {
                         loader: 'css-loader',
                         options: {

--- a/docs/settings-webpack.md
+++ b/docs/settings-webpack.md
@@ -173,7 +173,7 @@ analyze: {
 An array of [extra plugins](https://webpack.js.org/configuration/plugins) to add to the production build.
 
 ## `cssLoaderOptions`
-An object to pass to `css-loader` options, all supported options can be found [here](https://github.com/webpack-contrib/css-loader#options)
+An object of options to pass to [css-loader](https://github.com/webpack-contrib/css-loader#options).
 
 ## `server`
 Webpack settings for serverside builds.

--- a/docs/settings-webpack.md
+++ b/docs/settings-webpack.md
@@ -172,6 +172,9 @@ analyze: {
 #### `plugins`
 An array of [extra plugins](https://webpack.js.org/configuration/plugins) to add to the production build.
 
+## `cssLoaderOptions`
+An object to pass to `css-loader` options, all supported options can be found [here](https://github.com/webpack-contrib/css-loader#options)
+
 ## `server`
 Webpack settings for serverside builds.
 


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/FED-119

**Description**
Gives ability to pass options to `css-loader`

Purpose is to get rid of all this stuff:
https://github.com/spothero/developer-portal/blob/staging/config/settings.js#L5-L54
