### PR TITLE
fix: Only pull in known variables from process.env

### DIFF
--- a/config/webpack/utils.js
+++ b/config/webpack/utils.js
@@ -17,19 +17,13 @@ module.exports = {
     getEnvVars: environment => {
         const envVars = {};
 
-        // forEach(process.env, (value, key) => {
-        //     if (knownEnvVars.indexOf(key) >= 0) {
-        //         envVars[key] = JSON.stringify(value);
-        //     }
-        // });
-
-        forEach(knownEnvVars, (key) => {
+        forEach(knownEnvVars, key => {
             const value = process.env[key];
-            
+
             if (value) {
                 envVars[key] = JSON.stringify(value);
             }
-        })
+        });
 
         return {
             ...envVars,

--- a/config/webpack/utils.js
+++ b/config/webpack/utils.js
@@ -1,13 +1,35 @@
 const forEach = require('lodash/forEach');
 const settingsConfig = require('../gulp/lib/get-settings-config');
 
+const knownEnvVars = [
+    'ACE_ASSET_PATH',
+    'ACE_CONFIG_PATH',
+    'ACE_DEPLOY_TYPE',
+    'ACE_ENVIRONMENT',
+    'ACE_NPM_EVENT',
+    'BABEL_ENV',
+    'INIT_CWD',
+    'NODE_ENV',
+    'SANDBOX_NAME',
+];
+
 module.exports = {
     getEnvVars: environment => {
         const envVars = {};
 
-        forEach(process.env, (value, key) => {
-            envVars[key] = JSON.stringify(value);
-        });
+        // forEach(process.env, (value, key) => {
+        //     if (knownEnvVars.indexOf(key) >= 0) {
+        //         envVars[key] = JSON.stringify(value);
+        //     }
+        // });
+
+        forEach(knownEnvVars, (key) => {
+            const value = process.env[key];
+            
+            if (value) {
+                envVars[key] = JSON.stringify(value);
+            }
+        })
 
         return {
             ...envVars,


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/FED-245

**Description**
- Prevent NPM_TOKEN and irrelevant env vars from ending up in production application code
- Refactoring so we only iterate over the handful of known variable names and not hundreds of possible variables