### PR TITLE
feat: Allow environment variable for CHUNK_PUBLIC_PATH

### DIFF
--- a/config/webpack/utils.js
+++ b/config/webpack/utils.js
@@ -11,6 +11,7 @@ const knownEnvVars = [
     'INIT_CWD',
     'NODE_ENV',
     'SANDBOX_NAME',
+    'CHUNK_PUBLIC_PATH',
 ];
 
 module.exports = {


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/FED-248

**Description**
- Because all control panel sandbox files are in the same S3 bucket (unlike staging/prod, which have their own single-purpose buckets and Cloudfront rules set up), we need to grab files from S3 directly.
- This var will have to be accounted for in Dex.

See related PRs:
- control-panel: https://github.com/spothero/control-panel/pull/320
- Concourse: https://github.com/spothero/ord/pull/475